### PR TITLE
Add Linux and OSX support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
             <version>1.7.25</version>
         </dependency>
         <dependency>
-            <groupId>com.cosium.junixsocket</groupId>
+            <groupId>com.kohlschutter.junixsocket</groupId>
             <artifactId>junixsocket-common</artifactId>
             <version>2.0.4</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,12 @@
         <dependency>
             <groupId>com.cosium.junixsocket</groupId>
             <artifactId>junixsocket-common</artifactId>
-            <version>2.0.4.3</version>
+            <version>2.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.kohlschutter.junixsocket</groupId>
+            <artifactId>junixsocket-native-common</artifactId>
+            <version>2.0.4</version>
         </dependency>
     </dependencies>
     

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
         </dependency>
+        <dependency>
+            <groupId>com.cosium.junixsocket</groupId>
+            <artifactId>junixsocket-common</artifactId>
+            <version>2.0.4.3</version>
+        </dependency>
     </dependencies>
     
     <build>

--- a/src/main/java/com/jagrosh/discordipc/IPCClient.java
+++ b/src/main/java/com/jagrosh/discordipc/IPCClient.java
@@ -241,6 +241,7 @@ public final class IPCClient implements Closeable
     public void close()
     {
         checkConnected(true);
+
         try {
             pipe.close();
         } catch (IOException e) {

--- a/src/main/java/com/jagrosh/discordipc/IPCClient.java
+++ b/src/main/java/com/jagrosh/discordipc/IPCClient.java
@@ -20,17 +20,15 @@ import com.jagrosh.discordipc.entities.Packet.OpCode;
 import com.jagrosh.discordipc.entities.pipe.Pipe;
 import com.jagrosh.discordipc.entities.pipe.PipeStatus;
 import com.jagrosh.discordipc.exceptions.NoDiscordClientException;
-
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.lang.management.ManagementFactory;
-import java.util.HashMap;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
 
 /**
  * Represents a Discord IPC Client that can send and receive
@@ -243,7 +241,11 @@ public final class IPCClient implements Closeable
     public void close()
     {
         checkConnected(true);
-        pipe.close();
+        try {
+            pipe.close();
+        } catch (IOException e) {
+            LOGGER.debug("Failed to close pipe", e);
+        }
     }
 
     /**
@@ -444,7 +446,4 @@ public final class IPCClient implements Closeable
         String pr = ManagementFactory.getRuntimeMXBean().getName();
         return Integer.parseInt(pr.substring(0,pr.indexOf('@')));
     }
-
-    // a list of system property keys to get IPC file from different unix systems.
-    private final static String[] paths = {"XDG_RUNTIME_DIR","TMPDIR","TMP","TEMP"};
 }

--- a/src/main/java/com/jagrosh/discordipc/IPCClient.java
+++ b/src/main/java/com/jagrosh/discordipc/IPCClient.java
@@ -356,7 +356,7 @@ public final class IPCClient implements Closeable
                     {
                         case NULL:
                             if(nonce != null && callbacks.containsKey(nonce))
-                                callbacks.remove(nonce).succeed();
+                                callbacks.remove(nonce).succeed(p);
                             break;
                             
                         case ERROR:

--- a/src/main/java/com/jagrosh/discordipc/entities/Callback.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/Callback.java
@@ -35,7 +35,7 @@ public class Callback
      */
     public Callback()
     {
-        this(null, null);
+        this((Consumer<Packet>) null, null);
     }
 
     /**
@@ -62,6 +62,25 @@ public class Callback
     {
         this.success = success;
         this.failure = failure;
+    }
+
+    /**
+     * @param success The Runnable to launch after a successful process.
+     * @param failure The Consumer to launch if the process has an error.
+     */
+    @Deprecated
+    public Callback(Runnable success, Consumer<String> failure)
+    {
+        this(p -> success.run(), failure);
+    }
+
+    /**
+     * @param success The Runnable to launch after a successful process.
+     */
+    @Deprecated
+    public Callback(Runnable success)
+    {
+        this(p -> success.run(), null);
     }
 
     /**

--- a/src/main/java/com/jagrosh/discordipc/entities/Callback.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/Callback.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
  */
 public class Callback
 {
-    private final Runnable success;
+    private final Consumer<Packet> success;
     private final Consumer<String> failure;
 
     /**
@@ -39,38 +39,26 @@ public class Callback
     }
 
     /**
-     * Constructs a Callback with a success {@link Runnable} that
+     * Constructs a Callback with a success {@link Consumer} that
      * occurs when the process it is attached to executes without
      * error.
      *
-     * @param success The Runnable to launch after a successful process.
+     * @param success The Consumer to launch after a successful process.
      */
-    public Callback(Runnable success)
+    public Callback(Consumer<Packet> success)
     {
         this(success, null);
     }
 
     /**
-     * Constructs a Callback with a failure {@link Consumer} that
-     * occurs when the process it is attached to encounters an error,
-     * and whose parameter is the error message.
-     *
-     * @param failure The Consumer to launch if the process has an error.
-     */
-    public Callback(Consumer<String> failure)
-    {
-        this(null, failure);
-    }
-
-    /**
-     * Constructs a Callback with a success {@link Runnable} <i>and</i>
+     * Constructs a Callback with a success {@link Consumer} <i>and</i>
      * a failure {@link Consumer} that occurs when the process it is
      * attached to executes without or with error (respectively).
      *
-     * @param success The Runnable to launch after a successful process.
+     * @param success The Consumer to launch after a successful process.
      * @param failure The Consumer to launch if the process has an error.
      */
-    public Callback(Runnable success, Consumer<String> failure)
+    public Callback(Consumer<Packet> success, Consumer<String> failure)
     {
         this.success = success;
         this.failure = failure;
@@ -78,7 +66,7 @@ public class Callback
 
     /**
      * Gets whether or not this Callback is "empty" which is more precisely
-     * defined as not having a specified success {@link Runnable} and/or a
+     * defined as not having a specified success {@link Consumer} and/or a
      * failure {@link Consumer}.<br>
      * This is only true if the Callback is constructed with the parameter-less
      * constructor ({@link #Callback()}) or another constructor that leaves
@@ -92,12 +80,12 @@ public class Callback
     }
 
     /**
-     * Launches the success {@link Runnable}.
+     * Launches the success {@link Consumer}.
      */
-    public void succeed()
+    public void succeed(Packet packet)
     {
         if(success != null)
-            success.run();
+            success.accept(packet);
     }
 
     /**

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/Pipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/Pipe.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2017 John Grosh (john.a.grosh@gmail.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jagrosh.discordipc.entities.pipe;
+
+import com.jagrosh.discordipc.IPCClient;
+import com.jagrosh.discordipc.IPCListener;
+import com.jagrosh.discordipc.entities.Callback;
+import com.jagrosh.discordipc.entities.DiscordBuild;
+import com.jagrosh.discordipc.entities.Packet;
+import com.jagrosh.discordipc.exceptions.NoDiscordClientException;
+import com.sun.javafx.PlatformUtil;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.UUID;
+
+public abstract class Pipe {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Pipe.class);
+    static final int VERSION = 1;
+    PipeStatus status = PipeStatus.CONNECTING;
+    IPCListener listener;
+    DiscordBuild build;
+    final IPCClient ipcClient;
+    final long clientId;
+    final HashMap<String,Callback> callbacks;
+
+    Pipe(IPCClient ipcClient, long clientId, HashMap<String, Callback> callbacks)
+    {
+        this.ipcClient = ipcClient;
+        this.clientId = clientId;
+        this.callbacks = callbacks;
+    }
+
+    public static Pipe openPipe(IPCClient ipcClient, long clientId, HashMap<String,Callback> callbacks,
+                                DiscordBuild... preferredOrder) throws NoDiscordClientException
+    {
+        if (PlatformUtil.isWindows())
+        {
+            return WindowsPipe.openPipe(ipcClient, clientId, callbacks, preferredOrder);
+        }
+        else if (PlatformUtil.isUnix())
+        {
+            return null; //TODO
+        }
+        else
+        {
+            throw new RuntimeException("Unsupported OS: " + System.getProperty("os.name"));
+        }
+    }
+
+    /**
+     * Sends json with the given {@link Packet.OpCode}.
+     *
+     * @param op The {@link Packet.OpCode} to send data with.
+     * @param data The data to send.
+     * @param callback callback for the response
+     */
+    public void send(Packet.OpCode op, JSONObject data, Callback callback)
+    {
+        try
+        {
+            String nonce = generateNonce();
+            Packet p = new Packet(op, data.put("nonce",nonce));
+            if(callback!=null && !callback.isEmpty())
+                callbacks.put(nonce, callback);
+            write(p.toBytes());
+            LOGGER.debug(String.format("Sent packet: %s", p.toString()));
+            if(listener != null)
+                listener.onPacketSent(ipcClient, p);
+        }
+        catch(IOException ex)
+        {
+            LOGGER.error("Encountered an IOException while sending a packet and disconnected!");
+            status = PipeStatus.DISCONNECTED;
+        }
+    }
+
+    public abstract void write(byte[] b) throws IOException;
+
+    /**
+     * Blocks until reading a {@link Packet} or until the
+     * read thread encounters bad data.
+     *
+     * @return A valid {@link Packet}.
+     *
+     * @throws IOException
+     *         If the pipe breaks.
+     * @throws JSONException
+     *         If the read thread receives bad data.
+     */
+    public abstract Packet read() throws IOException, JSONException;
+
+    /**
+     * Generates a nonce.
+     *
+     * @return A random {@link UUID}.
+     */
+    private static String generateNonce()
+    {
+        return UUID.randomUUID().toString();
+    }
+
+    public PipeStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(PipeStatus status) {
+        this.status = status;
+    }
+
+    public void setListener(IPCListener listener)
+    {
+        this.listener = listener;
+    }
+
+    public void close()
+    {
+        LOGGER.debug("Closing IPC pipe...");
+        send(Packet.OpCode.CLOSE, new JSONObject(), null);
+        status = PipeStatus.CLOSED;
+    }
+
+    public DiscordBuild getDiscordBuild()
+    {
+        return build;
+    }
+}

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/Pipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/Pipe.java
@@ -22,7 +22,6 @@ import com.jagrosh.discordipc.entities.Callback;
 import com.jagrosh.discordipc.entities.DiscordBuild;
 import com.jagrosh.discordipc.entities.Packet;
 import com.jagrosh.discordipc.exceptions.NoDiscordClientException;
-import com.sun.javafx.PlatformUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -152,11 +151,13 @@ public abstract class Pipe {
     }
 
     private static Pipe createPipe(IPCClient ipcClient, HashMap<String, Callback> callbacks, String location) {
-        if (PlatformUtil.isWindows())
+        String osName = System.getProperty("os.name").toLowerCase();
+
+        if (osName.contains("win"))
         {
             return new WindowsPipe(ipcClient, callbacks, location);
         }
-        else if (PlatformUtil.isUnix() || PlatformUtil.isMac())
+        else if (osName.contains("linux") || osName.contains("mac"))
         {
             try {
                 return new UnixPipe(ipcClient, callbacks, location);
@@ -168,7 +169,7 @@ public abstract class Pipe {
         }
         else
         {
-            throw new RuntimeException("Unsupported OS: " + System.getProperty("os.name"));
+            throw new RuntimeException("Unsupported OS: " + osName);
         }
     }
 

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/PipeStatus.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/PipeStatus.java
@@ -1,0 +1,60 @@
+package com.jagrosh.discordipc.entities.pipe;
+
+import com.jagrosh.discordipc.IPCClient;
+import com.jagrosh.discordipc.IPCListener;
+import com.jagrosh.discordipc.entities.DiscordBuild;
+import com.jagrosh.discordipc.entities.Packet;
+
+/**
+ * Constants representing various status that an {@link IPCClient} can have.
+ */
+public enum PipeStatus
+{
+    /**
+     * Status for when the IPCClient when no attempt to connect has been made.<p>
+     *
+     * All IPCClients are created starting with this status,
+     * and it never returns for the lifespan of the client.
+     */
+    UNINITIALIZED,
+
+    /**
+     * Status for when the Pipe is attempting to connect.<p>
+     *
+     * This will become set whenever the #connect() method is called.
+     */
+    CONNECTING,
+
+    /**
+     * Status for when the Pipe is connected with Discord.<p>
+     *
+     * This is only present when the connection is healthy, stable,
+     * and reading good data without exception.<br>
+     * If the environment becomes out of line with these principles
+     * in any way, the IPCClient in question will become
+     * {@link PipeStatus#DISCONNECTED}.
+     */
+    CONNECTED,
+
+    /**
+     * Status for when the Pipe has received an {@link Packet.OpCode#CLOSE}.<p>
+     *
+     * This signifies that the reading thread has safely and normally shut
+     * and the client is now inactive.
+     */
+    CLOSED,
+
+    /**
+     * Status for when the Pipe has unexpectedly disconnected, either because
+     * of an exception, and/or due to bad data.<p>
+     *
+     * When the status of an Pipe becomes this, a call to
+     * {@link IPCListener#onDisconnect(IPCClient, Throwable)} will be made if one
+     * has been provided to the IPCClient.<p>
+     *
+     * Note that the IPCClient will be inactive with this status, after which a
+     * call to {@link IPCClient#connect(DiscordBuild...)} can be made to "reconnect" the
+     * IPCClient.
+     */
+    DISCONNECTED
+}

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/PipeStatus.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/PipeStatus.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 John Grosh (john.a.grosh@gmail.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.jagrosh.discordipc.entities.pipe;
 
 import com.jagrosh.discordipc.IPCClient;

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/UnixPipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/UnixPipe.java
@@ -20,34 +20,85 @@ import com.jagrosh.discordipc.IPCClient;
 import com.jagrosh.discordipc.entities.Callback;
 import com.jagrosh.discordipc.entities.Packet;
 import org.json.JSONException;
+import org.json.JSONObject;
+import org.newsclub.net.unix.AFUNIXSocket;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 
 public class UnixPipe extends Pipe
 {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(WindowsPipe.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnixPipe.class);
+    private final AFUNIXSocket socket;
 
-    UnixPipe(IPCClient ipcClient, long clientId, HashMap<String, Callback> callbacks, String location)
+    UnixPipe(IPCClient ipcClient, HashMap<String, Callback> callbacks, String location) throws IOException
     {
-        super(ipcClient, clientId, callbacks);
+        super(ipcClient, callbacks);
+
+        socket = AFUNIXSocket.newInstance();
+        socket.connect(new AFUNIXSocketAddress(new File(location)));
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Override
+    public Packet read() throws IOException, JSONException
+    {
+        InputStream is = socket.getInputStream();
+
+        while(is.available() == 0 && status == PipeStatus.CONNECTED)
+        {
+            try {
+                Thread.sleep(50);
+            } catch(InterruptedException ignored) {}
+        }
+
+        /*byte[] buf = new byte[is.available()];
+        is.read(buf, 0, buf.length);
+        LOGGER.info(new String(buf));
+
+        if (true) return null;*/
+
+        if(status==PipeStatus.DISCONNECTED)
+            throw new IOException("Disconnected!");
+
+        if(status==PipeStatus.CLOSED)
+            return new Packet(Packet.OpCode.CLOSE, null);
+
+        // Read the op and length. Both are signed ints
+        byte[] d = new byte[8];
+        is.read(d);
+        ByteBuffer bb = ByteBuffer.wrap(d);
+
+        Packet.OpCode op = Packet.OpCode.values()[Integer.reverseBytes(bb.getInt())];
+        d = new byte[Integer.reverseBytes(bb.getInt())];
+
+        is.read(d);
+        Packet p = new Packet(op, new JSONObject(new String(d)));
+        LOGGER.debug(String.format("Received packet: %s", p.toString()));
+        if(listener != null)
+            listener.onPacketReceived(ipcClient, p);
+        return p;
     }
 
     @Override
-    public void write(byte[] b) throws IOException {
-
+    public void write(byte[] b) throws IOException
+    {
+        socket.getOutputStream().write(b);
     }
 
     @Override
-    public Packet read() throws IOException, JSONException {
-        return null;
-    }
-
-    @Override
-    public void close() throws IOException {
-        
+    public void close() throws IOException
+    {
+        LOGGER.debug("Closing IPC pipe...");
+        send(Packet.OpCode.CLOSE, new JSONObject(), null);
+        status = PipeStatus.CLOSED;
+        socket.close();
     }
 }

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/UnixPipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/UnixPipe.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 John Grosh (john.a.grosh@gmail.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jagrosh.discordipc.entities.pipe;
+
+import com.jagrosh.discordipc.IPCClient;
+import com.jagrosh.discordipc.entities.Callback;
+import com.jagrosh.discordipc.entities.Packet;
+import org.json.JSONException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class UnixPipe extends Pipe
+{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WindowsPipe.class);
+
+    UnixPipe(IPCClient ipcClient, long clientId, HashMap<String, Callback> callbacks, String location)
+    {
+        super(ipcClient, clientId, callbacks);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+
+    }
+
+    @Override
+    public Packet read() throws IOException, JSONException {
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        
+    }
+}

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/WindowsPipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/WindowsPipe.java
@@ -36,9 +36,9 @@ public class WindowsPipe extends Pipe
 
     private final RandomAccessFile file;
 
-    WindowsPipe(IPCClient ipcClient, long clientId, HashMap<String, Callback> callbacks, String location)
+    WindowsPipe(IPCClient ipcClient, HashMap<String, Callback> callbacks, String location)
     {
-        super(ipcClient, clientId, callbacks);
+        super(ipcClient, callbacks);
         try {
             this.file = new RandomAccessFile(location, "rw");
         } catch (FileNotFoundException e) {

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/WindowsPipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/WindowsPipe.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2017 John Grosh (john.a.grosh@gmail.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jagrosh.discordipc.entities.pipe;
+
+import com.jagrosh.discordipc.IPCClient;
+import com.jagrosh.discordipc.entities.Callback;
+import com.jagrosh.discordipc.entities.DiscordBuild;
+import com.jagrosh.discordipc.entities.Packet;
+import com.jagrosh.discordipc.exceptions.NoDiscordClientException;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.HashMap;
+
+public class WindowsPipe extends Pipe
+{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WindowsPipe.class);
+
+    private final RandomAccessFile file;
+
+    public static Pipe openPipe(IPCClient ipcClient, long clientId, HashMap<String, Callback> callbacks, DiscordBuild... preferredOrder) throws NoDiscordClientException {
+        if(preferredOrder == null || preferredOrder.length == 0)
+            preferredOrder = new DiscordBuild[]{DiscordBuild.ANY};
+
+        WindowsPipe pipe = null;
+
+        // store some files so we can get the preferred client
+        WindowsPipe[] open = new WindowsPipe[DiscordBuild.values().length];
+        for(int i = 0; i < 10; i++)
+        {
+            try
+            {
+                String location = getIPC(i);
+                LOGGER.debug(String.format("Searching for IPC: %s", location));
+                pipe = new WindowsPipe(ipcClient, clientId, callbacks, location);
+
+                pipe.send(Packet.OpCode.HANDSHAKE, new JSONObject().put("v", VERSION).put("client_id", Long.toString(clientId)), null);
+
+                Packet p = pipe.read(); // this is a valid client at this point
+
+                pipe.build = DiscordBuild.from(p.getJson().getJSONObject("data")
+                        .getJSONObject("config")
+                        .getString("api_endpoint"));
+
+                LOGGER.debug(String.format("Found a valid client (%s) with packet: %s", pipe.build.name(), p.toString()));
+                // we're done if we found our first choice
+                if(pipe.build == preferredOrder[0] || DiscordBuild.ANY == preferredOrder[0]) {
+                    LOGGER.info(String.format("Found preferred client: %s", pipe.build.name()));
+                    break;
+                }
+
+                open[pipe.build.ordinal()] = pipe; // didn't find first choice yet, so store what we have
+                open[DiscordBuild.ANY.ordinal()] = pipe; // also store in 'any' for use later
+
+                pipe.build = null;
+                pipe = null;
+            }
+            catch(IOException | JSONException ex)
+            {
+                pipe = null;
+            }
+        }
+
+        if(pipe == null)
+        {
+            // we already know we don't have our first pick
+            // check each of the rest to see if we have that
+            for(int i = 1; i < preferredOrder.length; i++)
+            {
+                DiscordBuild cb = preferredOrder[i];
+                LOGGER.debug(String.format("Looking for client build: %s", cb.name()));
+                if(open[cb.ordinal()] != null)
+                {
+                    pipe = open[cb.ordinal()];
+                    open[cb.ordinal()] = null;
+                    if(cb == DiscordBuild.ANY) // if we pulled this from the 'any' slot, we need to figure out which build it was
+                    {
+                        for(int k = 0; k < open.length; k++)
+                        {
+                            if(open[k] == pipe)
+                            {
+                                pipe.build = DiscordBuild.values()[k];
+                                open[k] = null; // we don't want to close this
+                            }
+                        }
+                    }
+                    else pipe.build = cb;
+
+                    LOGGER.info(String.format("Found preferred client: %s", pipe.build.name()));
+                    break;
+                }
+            }
+            if(pipe == null)
+            {
+                throw new NoDiscordClientException();
+            }
+        }
+        // close unused files, except skip 'any' because its always a duplicate
+        for(int i = 0; i < open.length; i++)
+        {
+            if(i == DiscordBuild.ANY.ordinal())
+                continue;
+            if(open[i] != null)
+            {
+                try {
+                    open[i].file.close();
+                } catch(IOException ex) {
+                    // This isn't really important to applications and better
+                    // as debug info
+                    LOGGER.debug("Failed to close an open IPC pipe!", ex);
+                }
+            }
+        }
+
+        pipe.status = PipeStatus.CONNECTED;
+
+        return pipe;
+    }
+
+    private WindowsPipe(IPCClient ipcClient, long clientId, HashMap<String, Callback> callbacks, String location)
+    {
+        super(ipcClient, clientId, callbacks);
+        try {
+            this.file = new RandomAccessFile(location, "rw");
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        file.write(b);
+    }
+
+    @Override
+    public Packet read() throws IOException, JSONException {
+        while(file.length() == 0 && status == PipeStatus.CONNECTED)
+        {
+            try {
+                Thread.sleep(50);
+            } catch(InterruptedException ignored) {}
+        }
+
+        if(status==PipeStatus.DISCONNECTED)
+            throw new IOException("Disconnected!");
+
+        if(status==PipeStatus.CLOSED)
+            return new Packet(Packet.OpCode.CLOSE, null);
+
+        Packet.OpCode op = Packet.OpCode.values()[Integer.reverseBytes(file.readInt())];
+        int len = Integer.reverseBytes(file.readInt());
+        byte[] d = new byte[len];
+
+        file.readFully(d);
+        Packet p = new Packet(op, new JSONObject(new String(d)));
+        LOGGER.debug(String.format("Received packet: %s", p.toString()));
+        if(listener != null)
+            listener.onPacketReceived(ipcClient, p);
+        return p;
+    }
+
+    /**
+     * Finds the IPC location in the current system.
+     *
+     * @param i Index to try getting the IPC at.
+     *
+     * @return The IPC location.
+     */
+    private static String getIPC(int i)
+    {
+        return "\\\\?\\pipe\\discord-ipc-"+i;
+    }
+
+}

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/WindowsPipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/WindowsPipe.java
@@ -18,9 +18,7 @@ package com.jagrosh.discordipc.entities.pipe;
 
 import com.jagrosh.discordipc.IPCClient;
 import com.jagrosh.discordipc.entities.Callback;
-import com.jagrosh.discordipc.entities.DiscordBuild;
 import com.jagrosh.discordipc.entities.Packet;
-import com.jagrosh.discordipc.exceptions.NoDiscordClientException;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -38,106 +36,7 @@ public class WindowsPipe extends Pipe
 
     private final RandomAccessFile file;
 
-    public static Pipe openPipe(IPCClient ipcClient, long clientId, HashMap<String, Callback> callbacks, DiscordBuild... preferredOrder) throws NoDiscordClientException {
-        if(preferredOrder == null || preferredOrder.length == 0)
-            preferredOrder = new DiscordBuild[]{DiscordBuild.ANY};
-
-        WindowsPipe pipe = null;
-
-        // store some files so we can get the preferred client
-        WindowsPipe[] open = new WindowsPipe[DiscordBuild.values().length];
-        for(int i = 0; i < 10; i++)
-        {
-            try
-            {
-                String location = getIPC(i);
-                LOGGER.debug(String.format("Searching for IPC: %s", location));
-                pipe = new WindowsPipe(ipcClient, clientId, callbacks, location);
-
-                pipe.send(Packet.OpCode.HANDSHAKE, new JSONObject().put("v", VERSION).put("client_id", Long.toString(clientId)), null);
-
-                Packet p = pipe.read(); // this is a valid client at this point
-
-                pipe.build = DiscordBuild.from(p.getJson().getJSONObject("data")
-                        .getJSONObject("config")
-                        .getString("api_endpoint"));
-
-                LOGGER.debug(String.format("Found a valid client (%s) with packet: %s", pipe.build.name(), p.toString()));
-                // we're done if we found our first choice
-                if(pipe.build == preferredOrder[0] || DiscordBuild.ANY == preferredOrder[0]) {
-                    LOGGER.info(String.format("Found preferred client: %s", pipe.build.name()));
-                    break;
-                }
-
-                open[pipe.build.ordinal()] = pipe; // didn't find first choice yet, so store what we have
-                open[DiscordBuild.ANY.ordinal()] = pipe; // also store in 'any' for use later
-
-                pipe.build = null;
-                pipe = null;
-            }
-            catch(IOException | JSONException ex)
-            {
-                pipe = null;
-            }
-        }
-
-        if(pipe == null)
-        {
-            // we already know we don't have our first pick
-            // check each of the rest to see if we have that
-            for(int i = 1; i < preferredOrder.length; i++)
-            {
-                DiscordBuild cb = preferredOrder[i];
-                LOGGER.debug(String.format("Looking for client build: %s", cb.name()));
-                if(open[cb.ordinal()] != null)
-                {
-                    pipe = open[cb.ordinal()];
-                    open[cb.ordinal()] = null;
-                    if(cb == DiscordBuild.ANY) // if we pulled this from the 'any' slot, we need to figure out which build it was
-                    {
-                        for(int k = 0; k < open.length; k++)
-                        {
-                            if(open[k] == pipe)
-                            {
-                                pipe.build = DiscordBuild.values()[k];
-                                open[k] = null; // we don't want to close this
-                            }
-                        }
-                    }
-                    else pipe.build = cb;
-
-                    LOGGER.info(String.format("Found preferred client: %s", pipe.build.name()));
-                    break;
-                }
-            }
-            if(pipe == null)
-            {
-                throw new NoDiscordClientException();
-            }
-        }
-        // close unused files, except skip 'any' because its always a duplicate
-        for(int i = 0; i < open.length; i++)
-        {
-            if(i == DiscordBuild.ANY.ordinal())
-                continue;
-            if(open[i] != null)
-            {
-                try {
-                    open[i].file.close();
-                } catch(IOException ex) {
-                    // This isn't really important to applications and better
-                    // as debug info
-                    LOGGER.debug("Failed to close an open IPC pipe!", ex);
-                }
-            }
-        }
-
-        pipe.status = PipeStatus.CONNECTED;
-
-        return pipe;
-    }
-
-    private WindowsPipe(IPCClient ipcClient, long clientId, HashMap<String, Callback> callbacks, String location)
+    WindowsPipe(IPCClient ipcClient, long clientId, HashMap<String, Callback> callbacks, String location)
     {
         super(ipcClient, clientId, callbacks);
         try {
@@ -179,16 +78,12 @@ public class WindowsPipe extends Pipe
         return p;
     }
 
-    /**
-     * Finds the IPC location in the current system.
-     *
-     * @param i Index to try getting the IPC at.
-     *
-     * @return The IPC location.
-     */
-    private static String getIPC(int i)
-    {
-        return "\\\\?\\pipe\\discord-ipc-"+i;
+    @Override
+    public void close() throws IOException {
+        LOGGER.debug("Closing IPC pipe...");
+        send(Packet.OpCode.CLOSE, new JSONObject(), null);
+        status = PipeStatus.CLOSED;
+        file.close();
     }
 
 }


### PR DESCRIPTION
Summary:
* Added an abstract class called `Pipe`
* Add support for Unix sockets in addition to named pipes on Windows
* Delegated much of the logic out of IPCClient
* Semi-breaking because of changes to the status enum

Fixes #7 

Only tested on Linux