### PR TITLE
Add Unicode support

### DIFF
--- a/src/main/java/com/jagrosh/discordipc/entities/Packet.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/Packet.java
@@ -16,6 +16,7 @@
 package com.jagrosh.discordipc.entities;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import org.json.JSONObject;
 
 /**
@@ -48,7 +49,7 @@ public class Packet
      */
     public byte[] toBytes()
     {
-        byte[] d = data.toString().getBytes();
+        byte[] d = data.toString().getBytes(StandardCharsets.UTF_8);
         ByteBuffer packet = ByteBuffer.allocate(d.length + 2*Integer.BYTES);
         packet.putInt(Integer.reverseBytes(op.ordinal()));
         packet.putInt(Integer.reverseBytes(d.length));


### PR DESCRIPTION
Discord appears to accept UTF-8 encoded text. However, when decoding the string to bytes, the Packet class doesn't specify a charset, which will use the system default by default. At least on Windows computers, this will cause non-ASCII characters to be translated into `?`s. This PR explicitly converts text to UTF-8.

I haven't had the opportunity to test on Linux or Mac, but I assume Discord accepts UTF-8 text on those systems as well.