### PR TITLE
Update all the libs!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,22 +10,22 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20171018</version>
+            <version>20230227</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>com.kohlschutter.junixsocket</groupId>
             <artifactId>junixsocket-common</artifactId>
-            <version>2.0.4</version>
+            <version>2.6.2</version>
         </dependency>
         <dependency>
             <groupId>com.kohlschutter.junixsocket</groupId>
             <artifactId>junixsocket-native-common</artifactId>
-            <version>2.0.4</version>
+            <version>2.6.2</version>
         </dependency>
     </dependencies>
     

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/UnixPipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/UnixPipe.java
@@ -26,10 +26,10 @@ import org.newsclub.net.unix.AFUNIXSocketAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.file.Paths;
 import java.util.HashMap;
 
 public class UnixPipe extends Pipe
@@ -43,7 +43,7 @@ public class UnixPipe extends Pipe
         super(ipcClient, callbacks);
 
         socket = AFUNIXSocket.newInstance();
-        socket.connect(new AFUNIXSocketAddress(new File(location)));
+        socket.connect(AFUNIXSocketAddress.of(Paths.get(location)));
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")


### PR DESCRIPTION
Just this change so that people can continue to use this library on newer Java versions and Linux/macOS (presumably >= 9)!

Without this change you get this:
```
Exception in thread "main" java.lang.RuntimeException: org.newsclub.net.unix.AFUNIXSocketException: Cannot find method "setCreated" in java.net.Socket. Unsupported JVM?
	at com.jagrosh.discordipc.entities.pipe.Pipe.createPipe(Pipe.java:167)
	at com.jagrosh.discordipc.entities.pipe.Pipe.openPipe(Pipe.java:67)
	at com.jagrosh.discordipc.IPCClient.connect(IPCClient.java:116)
   [...]
Caused by: org.newsclub.net.unix.AFUNIXSocketException: Cannot find method "setCreated" in java.net.Socket. Unsupported JVM?
	at org.newsclub.net.unix.NativeUnixSocket.setCreated(Native Method)
	at org.newsclub.net.unix.AFUNIXSocket.<init>(AFUNIXSocket.java:36)
	at org.newsclub.net.unix.AFUNIXSocket.newInstance(AFUNIXSocket.java:54)
	at com.jagrosh.discordipc.entities.pipe.UnixPipe.<init>(UnixPipe.java:45)
	at com.jagrosh.discordipc.entities.pipe.Pipe.createPipe(Pipe.java:163)
	... 3 more
```

I realise there are other prs which do this, but i created this as a fix on its own as the other prs seem to change other things which may not be desired. and yes i've tested it on both java 8 and 17!