### PR TITLE
update libs (fixes ARM Mac support)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.jagrosh</groupId>
     <artifactId>DiscordIPC</artifactId>
-    <version>0.5</version>
+    <version>0.6</version>
     <packaging>jar</packaging>
     
     <dependencies>
@@ -11,11 +11,6 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20240303</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.1.0-alpha1</version>
         </dependency>
         <dependency>
             <groupId>com.kohlschutter.junixsocket</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,29 +3,29 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.jagrosh</groupId>
     <artifactId>DiscordIPC</artifactId>
-    <version>0.4</version>
+    <version>0.5</version>
     <packaging>jar</packaging>
     
     <dependencies>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20230227</version>
+            <version>20240303</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.7</version>
+            <version>2.1.0-alpha1</version>
         </dependency>
         <dependency>
             <groupId>com.kohlschutter.junixsocket</groupId>
             <artifactId>junixsocket-common</artifactId>
-            <version>2.6.2</version>
+            <version>${junixsocket.version}</version>
         </dependency>
         <dependency>
             <groupId>com.kohlschutter.junixsocket</groupId>
             <artifactId>junixsocket-native-common</artifactId>
-            <version>2.6.2</version>
+            <version>${junixsocket.version}</version>
         </dependency>
     </dependencies>
     
@@ -62,6 +62,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <junixsocket.version>2.9.0</junixsocket.version>
     </properties>
     <name>DiscordIPC</name>
 </project>

--- a/src/main/java/com/jagrosh/discordipc/IPCClient.java
+++ b/src/main/java/com/jagrosh/discordipc/IPCClient.java
@@ -20,10 +20,9 @@ import com.jagrosh.discordipc.entities.Packet.OpCode;
 import com.jagrosh.discordipc.entities.pipe.Pipe;
 import com.jagrosh.discordipc.entities.pipe.PipeStatus;
 import com.jagrosh.discordipc.exceptions.NoDiscordClientException;
+import com.jagrosh.discordipc.utils.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -55,7 +54,6 @@ import java.util.HashMap;
  */
 public final class IPCClient implements Closeable
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(IPCClient.class);
     private final long clientId;
     private final HashMap<String,Callback> callbacks = new HashMap<>();
     private volatile Pipe pipe;
@@ -115,7 +113,7 @@ public final class IPCClient implements Closeable
 
         pipe = Pipe.openPipe(this, clientId, callbacks, preferredOrder);
 
-        LOGGER.debug("Client is now connected and ready!");
+        Logger.debug("Client is now connected and ready!");
         if(listener != null)
             listener.onReady(this);
         startReading();
@@ -164,7 +162,7 @@ public final class IPCClient implements Closeable
     public void sendRichPresence(RichPresence presence, Callback callback)
     {
         checkConnected(true);
-        LOGGER.debug("Sending RichPresence to discord: "+(presence == null ? null : presence.toJson().toString()));
+        Logger.debug("Sending RichPresence to discord: "+(presence == null ? null : presence.toJson().toString()));
         pipe.send(OpCode.FRAME, new JSONObject()
                             .put("cmd","SET_ACTIVITY")
                             .put("args", new JSONObject()
@@ -211,7 +209,7 @@ public final class IPCClient implements Closeable
         checkConnected(true);
         if(!sub.isSubscribable())
             throw new IllegalStateException("Cannot subscribe to "+sub+" event!");
-        LOGGER.debug(String.format("Subscribing to Event: %s", sub.name()));
+        Logger.debug(String.format("Subscribing to Event: %s", sub.name()));
         pipe.send(OpCode.FRAME, new JSONObject()
                             .put("cmd", "SUBSCRIBE")
                             .put("evt", sub.name()), callback);
@@ -245,7 +243,7 @@ public final class IPCClient implements Closeable
         try {
             pipe.close();
         } catch (IOException e) {
-            LOGGER.debug("Failed to close pipe", e);
+            Logger.debug("Failed to close pipe");
         }
     }
 
@@ -365,19 +363,19 @@ public final class IPCClient implements Closeable
                             break;
                             
                         case ACTIVITY_JOIN:
-                            LOGGER.debug("Reading thread received a 'join' event.");
+                            Logger.debug("Reading thread received a 'join' event.");
                             break;
                             
                         case ACTIVITY_SPECTATE:
-                            LOGGER.debug("Reading thread received a 'spectate' event.");
+                            Logger.debug("Reading thread received a 'spectate' event.");
                             break;
                             
                         case ACTIVITY_JOIN_REQUEST:
-                            LOGGER.debug("Reading thread received a 'join request' event.");
+                            Logger.debug("Reading thread received a 'join request' event.");
                             break;
                             
                         case UNKNOWN:
-                            LOGGER.debug("Reading thread encountered an event with an unknown type: " +
+                            Logger.debug("Reading thread encountered an event with an unknown type: " +
                                          json.getString("evt"));
                             break;
                     }
@@ -410,7 +408,7 @@ public final class IPCClient implements Closeable
                         }
                         catch(Exception e)
                         {
-                            LOGGER.error("Exception when handling event: ", e);
+                            Logger.error("Exception when handling event: ");
                         }
                     }
                 }
@@ -421,9 +419,9 @@ public final class IPCClient implements Closeable
             catch(IOException | JSONException ex)
             {
                 if(ex instanceof IOException)
-                    LOGGER.error("Reading thread encountered an IOException", ex);
+                    Logger.error("Reading thread encountered an IOException");
                 else
-                    LOGGER.error("Reading thread encountered an JSONException", ex);
+                    Logger.error("Reading thread encountered an JSONException");
 
                 pipe.setStatus(PipeStatus.DISCONNECTED);
                 if(listener != null)
@@ -431,7 +429,7 @@ public final class IPCClient implements Closeable
             }
         });
 
-        LOGGER.debug("Starting IPCClient reading thread!");
+        Logger.debug("Starting IPCClient reading thread!");
         readThread.start();
     }
     

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/Pipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/Pipe.java
@@ -22,10 +22,9 @@ import com.jagrosh.discordipc.entities.Callback;
 import com.jagrosh.discordipc.entities.DiscordBuild;
 import com.jagrosh.discordipc.entities.Packet;
 import com.jagrosh.discordipc.exceptions.NoDiscordClientException;
+import com.jagrosh.discordipc.utils.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -33,7 +32,6 @@ import java.util.UUID;
 
 public abstract class Pipe {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Pipe.class);
     private static final int VERSION = 1;
     PipeStatus status = PipeStatus.CONNECTING;
     IPCListener listener;
@@ -63,7 +61,7 @@ public abstract class Pipe {
             try
             {
                 String location = getPipeLocation(i);
-                LOGGER.debug(String.format("Searching for IPC: %s", location));
+                Logger.debug(String.format("Searching for IPC: %s", location));
                 pipe = createPipe(ipcClient, callbacks, location);
 
                 pipe.send(Packet.OpCode.HANDSHAKE, new JSONObject().put("v", VERSION).put("client_id", Long.toString(clientId)), null);
@@ -74,11 +72,11 @@ public abstract class Pipe {
                         .getJSONObject("config")
                         .getString("api_endpoint"));
 
-                LOGGER.debug(String.format("Found a valid client (%s) with packet: %s", pipe.build.name(), p.toString()));
+                Logger.debug(String.format("Found a valid client (%s) with packet: %s", pipe.build.name(), p.toString()));
                 // we're done if we found our first choice
                 if(pipe.build == preferredOrder[0] || DiscordBuild.ANY == preferredOrder[0])
                 {
-                    LOGGER.info(String.format("Found preferred client: %s", pipe.build.name()));
+                    Logger.info(String.format("Found preferred client: %s", pipe.build.name()));
                     break;
                 }
 
@@ -101,7 +99,7 @@ public abstract class Pipe {
             for(int i = 1; i < preferredOrder.length; i++)
             {
                 DiscordBuild cb = preferredOrder[i];
-                LOGGER.debug(String.format("Looking for client build: %s", cb.name()));
+                Logger.debug(String.format("Looking for client build: %s", cb.name()));
                 if(open[cb.ordinal()] != null)
                 {
                     pipe = open[cb.ordinal()];
@@ -119,7 +117,7 @@ public abstract class Pipe {
                     }
                     else pipe.build = cb;
 
-                    LOGGER.info(String.format("Found preferred client: %s", pipe.build.name()));
+                    Logger.info(String.format("Found preferred client: %s", pipe.build.name()));
                     break;
                 }
             }
@@ -140,7 +138,7 @@ public abstract class Pipe {
                 } catch(IOException ex) {
                     // This isn't really important to applications and better
                     // as debug info
-                    LOGGER.debug("Failed to close an open IPC pipe!", ex);
+                    Logger.debug("Failed to close an open IPC pipe!");
                 }
             }
         }
@@ -189,13 +187,13 @@ public abstract class Pipe {
             if(callback!=null && !callback.isEmpty())
                 callbacks.put(nonce, callback);
             write(p.toBytes());
-            LOGGER.debug(String.format("Sent packet: %s", p.toString()));
+            Logger.debug(String.format("Sent packet: %s", p.toString()));
             if(listener != null)
                 listener.onPacketSent(ipcClient, p);
         }
         catch(IOException ex)
         {
-            LOGGER.error("Encountered an IOException while sending a packet and disconnected!");
+            Logger.error("Encountered an IOException while sending a packet and disconnected!");
             status = PipeStatus.DISCONNECTED;
         }
     }

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/UnixPipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/UnixPipe.java
@@ -19,12 +19,11 @@ package com.jagrosh.discordipc.entities.pipe;
 import com.jagrosh.discordipc.IPCClient;
 import com.jagrosh.discordipc.entities.Callback;
 import com.jagrosh.discordipc.entities.Packet;
+import com.jagrosh.discordipc.utils.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.newsclub.net.unix.AFUNIXSocket;
 import org.newsclub.net.unix.AFUNIXSocketAddress;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,7 +34,6 @@ import java.util.HashMap;
 public class UnixPipe extends Pipe
 {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UnixPipe.class);
     private final AFUNIXSocket socket;
 
     UnixPipe(IPCClient ipcClient, HashMap<String, Callback> callbacks, String location) throws IOException
@@ -81,7 +79,7 @@ public class UnixPipe extends Pipe
 
         is.read(d);
         Packet p = new Packet(op, new JSONObject(new String(d)));
-        LOGGER.debug(String.format("Received packet: %s", p.toString()));
+        Logger.debug(String.format("Received packet: %s", p.toString()));
         if(listener != null)
             listener.onPacketReceived(ipcClient, p);
         return p;
@@ -96,7 +94,7 @@ public class UnixPipe extends Pipe
     @Override
     public void close() throws IOException
     {
-        LOGGER.debug("Closing IPC pipe...");
+        Logger.debug("Closing IPC pipe...");
         send(Packet.OpCode.CLOSE, new JSONObject(), null);
         status = PipeStatus.CLOSED;
         socket.close();

--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/WindowsPipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/WindowsPipe.java
@@ -19,10 +19,9 @@ package com.jagrosh.discordipc.entities.pipe;
 import com.jagrosh.discordipc.IPCClient;
 import com.jagrosh.discordipc.entities.Callback;
 import com.jagrosh.discordipc.entities.Packet;
+import com.jagrosh.discordipc.utils.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -31,8 +30,6 @@ import java.util.HashMap;
 
 public class WindowsPipe extends Pipe
 {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(WindowsPipe.class);
 
     private final RandomAccessFile file;
 
@@ -72,7 +69,7 @@ public class WindowsPipe extends Pipe
 
         file.readFully(d);
         Packet p = new Packet(op, new JSONObject(new String(d)));
-        LOGGER.debug(String.format("Received packet: %s", p.toString()));
+        Logger.debug(String.format("Received packet: %s", p.toString()));
         if(listener != null)
             listener.onPacketReceived(ipcClient, p);
         return p;
@@ -80,7 +77,7 @@ public class WindowsPipe extends Pipe
 
     @Override
     public void close() throws IOException {
-        LOGGER.debug("Closing IPC pipe...");
+        Logger.debug("Closing IPC pipe...");
         send(Packet.OpCode.CLOSE, new JSONObject(), null);
         status = PipeStatus.CLOSED;
         file.close();

--- a/src/main/java/com/jagrosh/discordipc/utils/Logger.java
+++ b/src/main/java/com/jagrosh/discordipc/utils/Logger.java
@@ -1,0 +1,16 @@
+package com.jagrosh.discordipc.utils;
+
+public class Logger {
+    public static void debug(Object s) {
+        System.out.println("[Debug] " + s);
+    }
+    public static void info(Object s) {
+        System.out.println("[Info] " + s);
+    }
+    public static void warn(Object s) {
+        System.out.println("[Warn] " + s);
+    }
+    public static void error(Object s) {
+        System.out.println("[Error] " + s);
+    }
+}


### PR DESCRIPTION
This fixes the following exception on ARM Macs like M1 or M2
```

Caused by: java.lang.RuntimeException: Unhandled architecture/OS: aarch64-MacOSX
    at org.newsclub.net.unix.NarSystem.getAOLs(NarSystem.java:110)
    at org.newsclub.net.unix.NarSystem.loadLibrary(NarSystem.java:30)
    ... 28 more
```

By updating the newsclub unix socket to 2.9.0
