### PR TITLE
Added error message after FileNotFoundException

### DIFF
--- a/src/main/java/com/jagrosh/discordipc/entities/pipe/WindowsPipe.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/pipe/WindowsPipe.java
@@ -42,6 +42,7 @@ public class WindowsPipe extends Pipe
         try {
             this.file = new RandomAccessFile(location, "rw");
         } catch (FileNotFoundException e) {
+            LOGGER.error("Couldn't open IPCPipe. If you are using Java 22 or higher you might need to choose a lower version than Java 22.")
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
It seems that with Java 22 on Windows IPCPipes can't be accessed like before. This error message is important so the user knows why DiscordIPC is not working. Of course the excact message could be further specified.

This fixes #34  at least temporarily but it should be considered opening the IPCPipe through something else than the RandomAccessFile class if DiscordIPC is aimed to support future versions of Java.